### PR TITLE
Production pipeline: automated daily scrape + props with alerting

### DIFF
--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -27,6 +27,7 @@ jobs:
   scrape-and-update:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Checkout

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -6,7 +6,18 @@ on:
   schedule:
     # 3am US Eastern (8am UTC). Change to "0 3 * * *" for 3am UTC.
     - cron: "0 8 * * *"
-  workflow_dispatch: # Allow manual run from Actions tab
+  workflow_dispatch:
+    inputs:
+      skip_scrape:
+        description: "Skip gamelog scraping (use existing JSON)"
+        required: false
+        default: false
+        type: boolean
+      skip_props:
+        description: "Skip props pipeline entirely"
+        required: false
+        default: false
+        type: boolean
 
 env:
   BACKEND_DIR: nba-data-backend
@@ -38,6 +49,7 @@ jobs:
       - name: Rescrape gamelogs
         id: gamelogs
         timeout-minutes: 30
+        if: ${{ github.event.inputs.skip_scrape != 'true' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.gamelogs
         env:
@@ -66,9 +78,24 @@ jobs:
       - name: Fetch prop lines from SportsGameOdds API
         id: props-fetch
         timeout-minutes: 10
-        if: ${{ secrets.ODDS_API_KEY != '' }}
+        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --upcoming --max-objects 100 --min-remaining 200
+        env:
+          ODDS_API_KEY: ${{ secrets.ODDS_API_KEY }}
+        continue-on-error: true
+
+      - name: Check props API budget
+        id: budget
+        timeout-minutes: 1
+        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
+        run: |
+          cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --usage 2>&1 | tee /tmp/usage.txt
+          remaining=$(grep -oP 'Objects remaining:\s*\K\d+' /tmp/usage.txt || echo "unknown")
+          echo "remaining=${remaining}" >> $GITHUB_OUTPUT
+          if [[ "${remaining}" != "unknown" && "${remaining}" -lt 500 ]]; then
+            echo "::warning::Props API budget low: ${remaining} objects remaining"
+          fi
         env:
           ODDS_API_KEY: ${{ secrets.ODDS_API_KEY }}
         continue-on-error: true
@@ -76,7 +103,7 @@ jobs:
       - name: Update games table from API events (upcoming games)
         id: games-api
         timeout-minutes: 5
-        if: ${{ secrets.ODDS_API_KEY != '' }}
+        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games_from_api
         env:
@@ -86,7 +113,7 @@ jobs:
       - name: Insert player props into DB
         id: props-insert
         timeout-minutes: 5
-        if: ${{ secrets.ODDS_API_KEY != '' }}
+        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_props --json-dir=data/raw_json/2025-26
         env:
@@ -102,9 +129,6 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/revalidate" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_SECRET }}"
-        env:
-          APP_URL: ${{ secrets.APP_URL }}
-          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
         continue-on-error: true
 
       # ---- Phase 4: Health check ----
@@ -126,27 +150,63 @@ jobs:
       - name: Pipeline summary
         if: always()
         run: |
-          echo "## Daily Pipeline Summary - $(date -u '+%Y-%m-%d')" >> $GITHUB_STEP_SUMMARY
+          echo "## Daily Pipeline Summary - $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Rescrape gamelogs | ${{ steps.gamelogs.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Rescrape gamelogs | ${{ steps.gamelogs.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Update games | ${{ steps.games.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Update player_game_stats | ${{ steps.stats.outcome }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Fetch props | ${{ steps.props-fetch.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Props API budget | ${{ steps.budget.outputs.remaining || 'n/a' }} remaining |" >> $GITHUB_STEP_SUMMARY
           echo "| Update games from API | ${{ steps.games-api.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Insert player props | ${{ steps.props-insert.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Revalidate cache | ${{ steps.revalidate.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Health check | ${{ steps.health.outcome }} |" >> $GITHUB_STEP_SUMMARY
 
-      - name: Notify on failure
-        if: failure()
+      - name: Alert on step failures
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
+            const steps = {
+              'Rescrape gamelogs': '${{ steps.gamelogs.outcome || "skipped" }}',
+              'Update games': '${{ steps.games.outcome }}',
+              'Update player_game_stats': '${{ steps.stats.outcome }}',
+              'Fetch props': '${{ steps.props-fetch.outcome || "skipped" }}',
+              'Update games from API': '${{ steps.games-api.outcome || "skipped" }}',
+              'Insert player props': '${{ steps.props-insert.outcome || "skipped" }}',
+              'Revalidate cache': '${{ steps.revalidate.outcome }}',
+              'Health check': '${{ steps.health.outcome }}',
+            };
+            const failed = Object.entries(steps).filter(([, v]) => v === 'failure');
+            if (failed.length === 0) {
+              console.log('All steps passed or were skipped. No alert needed.');
+              return;
+            }
+            const failedNames = failed.map(([k]) => k).join(', ');
+            const stepList = Object.entries(steps)
+              .map(([k, v]) => {
+                const icon = v === 'success' ? '✅' : v === 'failure' ? '❌' : v === 'skipped' ? '⏭️' : '⚠️';
+                return `- ${icon} ${k}: \`${v}\``;
+              })
+              .join('\n');
+            const budget = '${{ steps.budget.outputs.remaining || "n/a" }}';
+            const budgetNote = budget !== 'n/a' && parseInt(budget) < 500
+              ? `\n\n⚠️ **Props API budget low**: ${budget} objects remaining`
+              : '';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Daily pipeline failed: ${new Date().toISOString().split('T')[0]}`,
-              body: `The daily scrape pipeline failed.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\nSteps:\n- Gamelogs: \`${{ steps.gamelogs.outcome }}\`\n- Games: \`${{ steps.games.outcome }}\`\n- Stats: \`${{ steps.stats.outcome }}\`\n- Props fetch: \`${{ steps.props-fetch.outcome || 'skipped' }}\`\n- Games API: \`${{ steps.games-api.outcome || 'skipped' }}\`\n- Props insert: \`${{ steps.props-insert.outcome || 'skipped' }}\`\n- Revalidate: \`${{ steps.revalidate.outcome }}\``,
-              labels: ['pipeline-failure']
+              title: `Pipeline alert: ${failed.length} step(s) failed — ${new Date().toISOString().split('T')[0]}`,
+              body: [
+                `The daily pipeline completed with **${failed.length} failed step(s)**: ${failedNames}.`,
+                '',
+                `[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                '',
+                '### Step Results',
+                stepList,
+                budgetNote,
+              ].join('\n'),
+              labels: ['pipeline-failure'],
             });

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -171,14 +171,14 @@ jobs:
         with:
           script: |
             const steps = {
-              'Rescrape gamelogs': '${{ steps.gamelogs.outcome || "skipped" }}',
-              'Update games': '${{ steps.games.outcome }}',
-              'Update player_game_stats': '${{ steps.stats.outcome }}',
-              'Fetch props': '${{ steps.props-fetch.outcome || "skipped" }}',
-              'Update games from API': '${{ steps.games-api.outcome || "skipped" }}',
-              'Insert player props': '${{ steps.props-insert.outcome || "skipped" }}',
-              'Revalidate cache': '${{ steps.revalidate.outcome }}',
-              'Health check': '${{ steps.health.outcome }}',
+              'Rescrape gamelogs': '${{ steps.gamelogs.outcome }}' || 'skipped',
+              'Update games': '${{ steps.games.outcome }}' || 'skipped',
+              'Update player_game_stats': '${{ steps.stats.outcome }}' || 'skipped',
+              'Fetch props': '${{ steps.props-fetch.outcome }}' || 'skipped',
+              'Update games from API': '${{ steps.games-api.outcome }}' || 'skipped',
+              'Insert player props': '${{ steps.props-insert.outcome }}' || 'skipped',
+              'Revalidate cache': '${{ steps.revalidate.outcome }}' || 'skipped',
+              'Health check': '${{ steps.health.outcome }}' || 'skipped',
             };
             const failed = Object.entries(steps).filter(([, v]) => v === 'failure');
             if (failed.length === 0) {
@@ -192,7 +192,7 @@ jobs:
                 return `- ${icon} ${k}: \`${v}\``;
               })
               .join('\n');
-            const budget = '${{ steps.budget.outputs.remaining || "n/a" }}';
+            const budget = '${{ steps.budget.outputs.remaining }}' || 'n/a';
             const budgetNote = budget !== 'n/a' && parseInt(budget) < 500
               ? `\n\n\u26A0\uFE0F **Props API budget low**: ${budget} objects remaining`
               : '';

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   scrape-and-update:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,6 +36,8 @@ jobs:
 
       # ---- Phase 1: Gamelog pipeline ----
       - name: Rescrape gamelogs
+        id: gamelogs
+        timeout-minutes: 30
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.gamelogs
         env:
@@ -43,12 +47,16 @@ jobs:
         # If scrape fails (rate limit, etc.), we still try to update from existing JSON
 
       - name: Update games table
+        id: games
+        timeout-minutes: 5
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
 
       - name: Update player_game_stats table
+        id: stats
+        timeout-minutes: 5
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_game_stats
         env:
@@ -56,6 +64,8 @@ jobs:
 
       # ---- Phase 2: Props pipeline (requires ODDS_API_KEY secret) ----
       - name: Fetch prop lines from SportsGameOdds API
+        id: props-fetch
+        timeout-minutes: 10
         if: ${{ secrets.ODDS_API_KEY != '' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --upcoming --max-objects 100 --min-remaining 200
@@ -64,6 +74,8 @@ jobs:
         continue-on-error: true
 
       - name: Update games table from API events (upcoming games)
+        id: games-api
+        timeout-minutes: 5
         if: ${{ secrets.ODDS_API_KEY != '' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games_from_api
@@ -72,6 +84,8 @@ jobs:
         continue-on-error: true
 
       - name: Insert player props into DB
+        id: props-insert
+        timeout-minutes: 5
         if: ${{ secrets.ODDS_API_KEY != '' }}
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_props --json-dir=data/raw_json/2025-26
@@ -83,9 +97,56 @@ jobs:
 
       # ---- Phase 3: Revalidate ----
       - name: Revalidate frontend cache
+        id: revalidate
+        timeout-minutes: 2
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/revalidate" \
             -H "Authorization: Bearer ${{ secrets.REVALIDATE_SECRET }}"
         env:
           APP_URL: ${{ secrets.APP_URL }}
           REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        continue-on-error: true
+
+      # ---- Phase 4: Health check ----
+      - name: Health check
+        id: health
+        if: always()
+        timeout-minutes: 1
+        run: |
+          response=$(curl -sf "${{ secrets.APP_URL }}/api/health" || echo "FAILED")
+          echo "Health check response: $response"
+          if echo "$response" | grep -q '"status":"ok"'; then
+            echo "Frontend is healthy"
+          else
+            echo "::warning::Frontend health check failed"
+          fi
+        continue-on-error: true
+
+      # ---- Phase 5: Reporting ----
+      - name: Pipeline summary
+        if: always()
+        run: |
+          echo "## Daily Pipeline Summary - $(date -u '+%Y-%m-%d')" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Rescrape gamelogs | ${{ steps.gamelogs.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Update games | ${{ steps.games.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Update player_game_stats | ${{ steps.stats.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Fetch props | ${{ steps.props-fetch.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Update games from API | ${{ steps.games-api.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Insert player props | ${{ steps.props-insert.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Revalidate cache | ${{ steps.revalidate.outcome }} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Daily pipeline failed: ${new Date().toISOString().split('T')[0]}`,
+              body: `The daily scrape pipeline failed.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\nSteps:\n- Gamelogs: \`${{ steps.gamelogs.outcome }}\`\n- Games: \`${{ steps.games.outcome }}\`\n- Stats: \`${{ steps.stats.outcome }}\`\n- Props fetch: \`${{ steps.props-fetch.outcome || 'skipped' }}\`\n- Games API: \`${{ steps.games-api.outcome || 'skipped' }}\`\n- Props insert: \`${{ steps.props-insert.outcome || 'skipped' }}\`\n- Revalidate: \`${{ steps.revalidate.outcome }}\``,
+              labels: ['pipeline-failure']
+            });

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   BACKEND_DIR: nba-data-backend
+  HAS_ODDS_KEY: ${{ secrets.ODDS_API_KEY != '' }}
 
 jobs:
   scrape-and-update:
@@ -49,7 +50,7 @@ jobs:
       - name: Rescrape gamelogs
         id: gamelogs
         timeout-minutes: 30
-        if: ${{ github.event.inputs.skip_scrape != 'true' }}
+        if: inputs.skip_scrape != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.gamelogs
         env:
@@ -78,7 +79,7 @@ jobs:
       - name: Fetch prop lines from SportsGameOdds API
         id: props-fetch
         timeout-minutes: 10
-        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
+        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --upcoming --max-objects 100 --min-remaining 200
         env:
@@ -88,7 +89,7 @@ jobs:
       - name: Check props API budget
         id: budget
         timeout-minutes: 1
-        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
+        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --usage 2>&1 | tee /tmp/usage.txt
           remaining=$(grep -oP 'Objects remaining:\s*\K\d+' /tmp/usage.txt || echo "unknown")
@@ -103,7 +104,7 @@ jobs:
       - name: Update games table from API events (upcoming games)
         id: games-api
         timeout-minutes: 5
-        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
+        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games_from_api
         env:
@@ -113,7 +114,7 @@ jobs:
       - name: Insert player props into DB
         id: props-insert
         timeout-minutes: 5
-        if: ${{ secrets.ODDS_API_KEY != '' && github.event.inputs.skip_props != 'true' }}
+        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_props --json-dir=data/raw_json/2025-26
         env:
@@ -187,18 +188,18 @@ jobs:
             const failedNames = failed.map(([k]) => k).join(', ');
             const stepList = Object.entries(steps)
               .map(([k, v]) => {
-                const icon = v === 'success' ? '✅' : v === 'failure' ? '❌' : v === 'skipped' ? '⏭️' : '⚠️';
+                const icon = v === 'success' ? '\u2705' : v === 'failure' ? '\u274C' : v === 'skipped' ? '\u23ED\uFE0F' : '\u26A0\uFE0F';
                 return `- ${icon} ${k}: \`${v}\``;
               })
               .join('\n');
             const budget = '${{ steps.budget.outputs.remaining || "n/a" }}';
             const budgetNote = budget !== 'n/a' && parseInt(budget) < 500
-              ? `\n\n⚠️ **Props API budget low**: ${budget} objects remaining`
+              ? `\n\n\u26A0\uFE0F **Props API budget low**: ${budget} objects remaining`
               : '';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Pipeline alert: ${failed.length} step(s) failed — ${new Date().toISOString().split('T')[0]}`,
+              title: `Pipeline alert: ${failed.length} step(s) failed \u2014 ${new Date().toISOString().split('T')[0]}`,
               body: [
                 `The daily pipeline completed with **${failed.length} failed step(s)**: ${failedNames}.`,
                 '',

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -43,9 +43,8 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           uv sync --project ${{ env.BACKEND_DIR }}
-        env:
-          PATH: ${{ github.home }}/.local/bin:${{ github.home }}/.cargo/bin:$PATH
 
       # ---- Phase 1: Gamelog pipeline ----
       - name: Rescrape gamelogs

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -1,11 +1,14 @@
-# Daily pipeline at 3am ET: gamelogs → games → player_game_stats → props → revalidate.
-# Required secrets: POSTGRES_URL, APP_URL, REVALIDATE_SECRET. Optional: SCRAPE_PROXIES, ODDS_API_KEY.
+# Daily pipeline: gamelogs + props at 7:30am ET, props-only refresh at 10am ET.
+# Required secrets: POSTGRES_URL, APP_URL, REVALIDATE_SECRET, GH_PAT.
+# Optional: SCRAPE_PROXIES, ODDS_API_KEY.
 name: Daily scrape
 
 on:
   schedule:
-    # 3am US Eastern (8am UTC). Change to "0 3 * * *" for 3am UTC.
-    - cron: "0 8 * * *"
+    # Times are UTC. During EST (Nov–Mar) these are 7:30am/10am ET.
+    # During EDT (Mar–Nov) they shift to 8:30am/11am ET.
+    - cron: "30 12 * * *"  # 7:30am ET — full pipeline (scrape + props)
+    - cron: "0 15 * * *"   # 10am ET   — props refresh only
   workflow_dispatch:
     inputs:
       skip_scrape:
@@ -30,6 +33,34 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Determine run mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            hour=$(date -u +%H)
+            # Morning run (12:30 UTC / 7:30am ET) = full pipeline; afternoon = props only
+            if [[ "$hour" -le 13 ]]; then
+              echo "run_scrape=true" >> $GITHUB_OUTPUT
+            else
+              echo "run_scrape=false" >> $GITHUB_OUTPUT
+            fi
+            echo "run_props=true" >> $GITHUB_OUTPUT
+            echo "Run mode: schedule (hour=$hour UTC)"
+          else
+            # Manual trigger — use inputs
+            if [[ "${{ inputs.skip_scrape }}" == "true" ]]; then
+              echo "run_scrape=false" >> $GITHUB_OUTPUT
+            else
+              echo "run_scrape=true" >> $GITHUB_OUTPUT
+            fi
+            if [[ "${{ inputs.skip_props }}" == "true" ]]; then
+              echo "run_props=false" >> $GITHUB_OUTPUT
+            else
+              echo "run_props=true" >> $GITHUB_OUTPUT
+            fi
+            echo "Run mode: manual (skip_scrape=${{ inputs.skip_scrape }}, skip_props=${{ inputs.skip_props }})"
+          fi
+
       - name: Checkout workspace
         uses: actions/checkout@v4
 
@@ -53,23 +84,22 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           uv sync --project ${{ env.BACKEND_DIR }}
 
-      # ---- Phase 1: Gamelog pipeline ----
+      # ---- Phase 1: Gamelog pipeline (morning run only) ----
       - name: Rescrape gamelogs
         id: gamelogs
         timeout-minutes: 30
-        if: inputs.skip_scrape != true
+        if: steps.mode.outputs.run_scrape == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.gamelogs
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           SCRAPE_PROXIES: ${{ secrets.SCRAPE_PROXIES }}
         continue-on-error: true
-        # If scrape fails (rate limit, etc.), we still try to update from existing JSON
 
       - name: Update games table
         id: games
         timeout-minutes: 5
-        if: inputs.skip_scrape != true
+        if: steps.mode.outputs.run_scrape == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games
         env:
@@ -78,17 +108,17 @@ jobs:
       - name: Update player_game_stats table
         id: stats
         timeout-minutes: 5
-        if: inputs.skip_scrape != true
+        if: steps.mode.outputs.run_scrape == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_game_stats
         env:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
 
-      # ---- Phase 2: Props pipeline (requires ODDS_API_KEY secret) ----
+      # ---- Phase 2: Props pipeline (every run, requires ODDS_API_KEY) ----
       - name: Fetch prop lines from SportsGameOdds API
         id: props-fetch
         timeout-minutes: 10
-        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
+        if: env.HAS_ODDS_KEY == 'true' && steps.mode.outputs.run_props == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --upcoming --max-objects 100 --min-remaining 200
         env:
@@ -98,7 +128,7 @@ jobs:
       - name: Check props API budget
         id: budget
         timeout-minutes: 1
-        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
+        if: env.HAS_ODDS_KEY == 'true' && steps.mode.outputs.run_props == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.data_collection.scrapers.props --usage 2>&1 | tee /tmp/usage.txt
           remaining=$(grep -oP 'Objects remaining:\s*\K\d+' /tmp/usage.txt || echo "unknown")
@@ -113,7 +143,7 @@ jobs:
       - name: Update games table from API events (upcoming games)
         id: games-api
         timeout-minutes: 5
-        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
+        if: env.HAS_ODDS_KEY == 'true' && steps.mode.outputs.run_props == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games_from_api
         env:
@@ -123,7 +153,7 @@ jobs:
       - name: Insert player props into DB
         id: props-insert
         timeout-minutes: 5
-        if: env.HAS_ODDS_KEY == 'true' && inputs.skip_props != true
+        if: env.HAS_ODDS_KEY == 'true' && steps.mode.outputs.run_props == 'true'
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_props --json-dir=data/raw_json/2025-26
         env:
@@ -160,19 +190,21 @@ jobs:
       - name: Pipeline summary
         if: always()
         run: |
-          echo "## Daily Pipeline Summary - $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY
+          mode="props-only"
+          if [[ "${{ steps.mode.outputs.run_scrape }}" == "true" ]]; then mode="full"; fi
+          echo "## Pipeline Summary — $(date -u '+%Y-%m-%d %H:%M UTC') (${mode})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Rescrape gamelogs | ${{ steps.gamelogs.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Update games | ${{ steps.games.outcome }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Update player_game_stats | ${{ steps.stats.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Update games | ${{ steps.games.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Update player_game_stats | ${{ steps.stats.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Fetch props | ${{ steps.props-fetch.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Props API budget | ${{ steps.budget.outputs.remaining || 'n/a' }} remaining |" >> $GITHUB_STEP_SUMMARY
           echo "| Update games from API | ${{ steps.games-api.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Insert player props | ${{ steps.props-insert.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Revalidate cache | ${{ steps.revalidate.outcome }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Health check | ${{ steps.health.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Revalidate cache | ${{ steps.revalidate.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Health check | ${{ steps.health.outcome || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Alert on step failures
         if: always()

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -30,8 +30,15 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Checkout
+      - name: Checkout workspace
         uses: actions/checkout@v4
+
+      - name: Checkout backend repo
+        uses: actions/checkout@v4
+        with:
+          repository: ThatcherMcc/nba-data-scraper
+          path: nba-data-backend
+          token: ${{ secrets.GH_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Update games table
         id: games
         timeout-minutes: 5
+        if: inputs.skip_scrape != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_games
         env:
@@ -77,6 +78,7 @@ jobs:
       - name: Update player_game_stats table
         id: stats
         timeout-minutes: 5
+        if: inputs.skip_scrape != true
         run: |
           cd ${{ env.BACKEND_DIR }} && uv run python -m src.api.update_db.update_db_player_game_stats
         env:

--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout backend repo
         uses: actions/checkout@v4
         with:
-          repository: ThatcherMcc/nba-data-scraper
+          repository: ThatcherMcc/nba-data-backend
           path: nba-data-backend
           token: ${{ secrets.GH_PAT }}
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,114 @@
+# Workspace Setup
+
+Clone the workspace and both sub-repos, then install dependencies.
+
+## 1. Clone Everything
+
+```bash
+# Workspace (contains directives, execution scripts, CI config)
+git clone https://github.com/ThatcherMcc/nba-analytics-workspace.git
+cd nba-analytics-workspace
+git checkout feat/edge-analytics-suite
+
+# Backend (Python data pipeline)
+git clone https://github.com/ThatcherMcc/nba-data-scraper.git nba-data-backend
+
+# Frontend (Next.js prop website)
+git clone https://github.com/ThatcherMcc/nba-prop-website.git
+cd nba-prop-website
+git checkout feat/edge-analytics-suite
+cd ..
+```
+
+## 2. Install Tools
+
+Requires [mise](https://mise.jdx.dev/) (manages Node 22.20.0 and Python 3.12):
+
+```bash
+# Install mise if you don't have it
+curl https://mise.jdx.dev/install.sh | sh
+
+# From workspace root — installs correct Node + Python versions
+mise install
+```
+
+Or install manually: **Node 22.20.0**, **Python 3.12**, **pnpm**, **uv**.
+
+## 3. Backend Setup
+
+```bash
+cd nba-data-backend
+uv sync          # creates .venv and installs all Python deps
+```
+
+Copy env file (get values from your existing `.env.local`):
+
+```bash
+cp .env.example .env.local   # then fill in values
+```
+
+Required env vars:
+- `POSTGRES_URL` — Neon connection string
+- `APP_URL` — Frontend URL (e.g. `https://nba-prop-website.vercel.app`)
+- `REVALIDATE_SECRET` — must match frontend
+
+Optional:
+- `SCRAPE_PROXIES` — comma-separated proxy list for Basketball Reference
+- `ODDS_API_KEY` — SportsGameOdds API key
+- `UPDATE_API_KEY` — API key for frontend write endpoints
+
+## 4. Frontend Setup
+
+```bash
+cd nba-prop-website
+pnpm install
+```
+
+Copy env file:
+
+```bash
+cp .env.example .env   # then fill in values
+```
+
+Required env vars:
+- `POSTGRES_URL` — same Neon connection string
+- `UPDATE_API_KEY` — must match backend
+- `REVALIDATE_SECRET` — must match backend
+
+## 5. Verify
+
+```bash
+# Backend — should connect to Neon and print schema
+cd nba-data-backend
+source .venv/bin/activate
+set -a && source .env.local && set +a
+python3 scripts/export_neon_schema.py
+
+# Frontend — should start dev server on localhost:3000
+cd ../nba-prop-website
+pnpm dev
+```
+
+## Quick Reference
+
+| What | Command | Where |
+|------|---------|-------|
+| Run daily pipeline | `./execution/nba_data/daily_gamelog_and_revalidate.sh` | workspace root |
+| Scrape gamelogs | `python3 -m src.data_collection.scrapers.gamelogs` | nba-data-backend/ (venv active) |
+| Fetch props | `python3 -m src.data_collection.scrapers.props --upcoming` | nba-data-backend/ (venv active) |
+| Load props to DB | `python3 -m src.api.update_db.update_db_player_props` | nba-data-backend/ (venv active) |
+| Frontend dev | `pnpm dev` | nba-prop-website/ |
+| Frontend build | `pnpm build` | nba-prop-website/ |
+
+## Pulling Updates
+
+```bash
+# From workspace root
+git pull
+
+# Backend
+cd nba-data-backend && git pull
+
+# Frontend
+cd ../nba-prop-website && git pull
+```

--- a/directives/infrastructure/github_actions_setup.md
+++ b/directives/infrastructure/github_actions_setup.md
@@ -1,0 +1,85 @@
+# GitHub Actions Setup — Daily Pipeline
+
+## Overview
+
+The daily scrape pipeline runs at **3:00 AM Eastern (8:00 AM UTC)** via `.github/workflows/daily-scrape.yml`. It scrapes gamelogs, updates the database, fetches prop lines, and revalidates the frontend cache.
+
+## Required Secrets
+
+Go to **Settings → Secrets and variables → Actions → New repository secret** and add:
+
+| Secret | Required | Value | Notes |
+|--------|----------|-------|-------|
+| `POSTGRES_URL` | Yes | Neon connection string | Starts with `postgresql://` or `postgres://` |
+| `APP_URL` | Yes | Frontend Vercel URL | e.g. `https://your-app.vercel.app` — **no trailing slash** |
+| `REVALIDATE_SECRET` | Yes | Auth token | Must match the `REVALIDATE_SECRET` in Vercel env vars |
+| `SCRAPE_PROXIES` | No | Comma-separated proxy URLs | Format: `http://user:pass@host:port,http://...` |
+| `ODDS_API_KEY` | No | SportsGameOdds API key | Enables automatic prop line fetching. Budget: 2,500 objects/month |
+
+## Vercel Environment Variables
+
+Ensure these match in your Vercel project settings (Settings → Environment Variables):
+
+| Variable | Must Match |
+|----------|-----------|
+| `POSTGRES_URL` | Same as GitHub secret |
+| `REVALIDATE_SECRET` | Same as GitHub secret |
+| `UPDATE_API_KEY` | Same as backend `.env.local` |
+
+## Testing
+
+### Manual Trigger
+
+1. Go to **Actions** tab in GitHub
+2. Select **"Daily scrape"** workflow
+3. Click **"Run workflow"**
+4. Optional: check "Skip gamelog scraping" or "Skip props pipeline" for faster test runs
+5. Watch the run — check the **Summary** tab for the results table
+
+### Verify Success
+
+After a run, check:
+- **Actions → run → Summary**: Shows step-by-step results table
+- **Health check**: `curl https://your-app.vercel.app/api/health` should return `{"status":"ok"}`
+- **Frontend**: Homepage should show fresh data with "Updated Xh ago" indicator
+
+### If It Fails
+
+- A GitHub Issue with label `pipeline-failure` is auto-created listing which steps failed
+- Check the run logs for error details
+- Common issues:
+  - Missing secrets → steps fail immediately
+  - Rate limiting → gamelog scrape fails (continues with existing data)
+  - Props budget exhausted → props steps are skipped
+
+## Pipeline Phases
+
+```
+Phase 1: Gamelog Pipeline
+  1. Scrape gamelogs from Basketball Reference (30min timeout)
+  2. Update games table from scraped data (5min)
+  3. Update player_game_stats table (5min)
+
+Phase 2: Props Pipeline (requires ODDS_API_KEY)
+  4. Fetch prop lines from SportsGameOdds API (10min)
+  5. Check API budget remaining (1min)
+  6. Update games from API events (5min)
+  7. Insert player props into DB (5min)
+
+Phase 3: Cache
+  8. Revalidate frontend cache via POST /api/revalidate (2min)
+
+Phase 4: Verification
+  9. Health check GET /api/health (1min)
+
+Phase 5: Reporting
+  10. Write summary to GitHub Step Summary
+  11. Create GitHub Issue if any step failed
+```
+
+## Monitoring
+
+- **Pipeline failures**: Auto-creates GitHub Issues with `pipeline-failure` label
+- **Budget warnings**: Props API budget < 500 objects triggers a warning annotation
+- **Health check**: GET `/api/health` returns DB connectivity + latency
+- **Step summary**: Every run produces a markdown table in the Actions Summary tab


### PR DESCRIPTION
## Summary
- Automated daily pipeline via GitHub Actions: gamelog scrape at 7:30am ET, props refresh at 10am ET
- Step-level failure alerting via GitHub Issues (works even with continue-on-error steps)
- Manual trigger with skip_scrape / skip_props options for flexible runs
- DOE architecture: directives, execution wrappers, and workspace setup docs

## What's included
- `.github/workflows/daily-scrape.yml` — multi-phase pipeline with run mode detection, budget monitoring, and failure alerts
- `directives/` — SOPs for data pipeline, infrastructure, and features
- `execution/` — wrapper scripts for all backend modules
- `CLAUDE.md` — agent operating instructions
- Workspace setup docs (`SETUP.md`, `ENV_SETUP.md`)

## Pipeline schedule
| Time (ET) | What runs |
|---|---|
| 7:30am | Full: scrape gamelogs → update games → update stats → fetch props → revalidate |
| 10:00am | Props only: fetch prop lines → insert to DB → revalidate |

## Test plan
- [x] Props-only run passed (3,291 rows upserted)
- [x] Full pipeline run passed (488/522 players scraped, 27,452 stats upserted)
- [x] Alert system verified (no-failure case: "No alert needed")
- [x] Manual trigger with skip options verified